### PR TITLE
Bug 870429 - Remove locales public field from Make model

### DIFF
--- a/lib/models/make.js
+++ b/lib/models/make.js
@@ -125,9 +125,9 @@ module.exports = function( environment, mongoInstance ) {
     }
   });
 
-  Make.publicFields = [ "url", "contentType", "locale", "locales",
+  Make.publicFields = [ "url", "contentType", "locale",
                         "title", "description", "author", "published", "tags",
                         "thumbnail", "remixedFrom" ];
-
+                        
   return Make;
 };


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=870429
We seem to have both locale and locales in our Make model (make.js):
Only locale should be there.
