### PR TITLE
Bug 869951 - enable backwards compatible tag filtering

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -15,6 +15,11 @@ module.exports = function( makeModel, apiUserModel, env ) {
   return {
     prefixAuth: function( req, res, next ) {
 
+      // Support older POST body formats for Makes
+      if ( req.body.maker && req.body.make ) {
+        req.body = req.body.make;
+      }
+
       var makerID = req.body.email,
           makeTags = req.body.tags,
           appTags = req.body.appTags,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=869951
