### PR TITLE
Bug 898139 - update makeapi-client version to v0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "habitat": "0.4.1",
     "hawk": "1.0.0",
     "helmet": "0.0.11",
-    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.5",
+    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.6",
     "mongoose": "3.5.2",
     "mongoose-validator": "0.2.1",
     "mongoosastic": "0.0.11",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=898139
