### PR TITLE
Fix Bug 912022 - Use match query instead of query_string query for title...

### DIFF
--- a/lib/queryBuilder.js
+++ b/lib/queryBuilder.js
@@ -65,10 +65,11 @@ module.exports = function( loginApi ) {
 
     description: function( description, not ) {
       return generateFilter( "query", {
-        query_string: {
-          query: description,
-          fields: [ "description" ],
-          default_operator: "AND"
+        match: {
+          description: {
+            query: description,
+            operator: "and"
+          }
         }
       }, not );
     },
@@ -118,10 +119,11 @@ module.exports = function( loginApi ) {
 
     title: function( title, not ) {
       return generateFilter( "query", {
-        query_string: {
-          query: title,
-          fields: [ "title" ],
-          default_operator: "AND"
+        match: {
+          title: {
+            query: title,
+            operator: "and"
+          }
         }
       }, not );
     },
@@ -158,7 +160,7 @@ module.exports = function( loginApi ) {
                     field: "deletedAt",
                     null_value: true
                   }
-                } 
+                }
               }
             }
           },

--- a/test/queryBuilder/complexQueries.unit.js
+++ b/test/queryBuilder/complexQueries.unit.js
@@ -62,12 +62,11 @@ module.exports = function( qb ) {
       filters: [
         {
           query: {
-            query_string: {
-              query: "This is a title",
-              fields: [
-                "title"
-              ],
-              default_operator: "AND"
+            match: {
+              title: {
+                query: "This is a title",
+                operator: "and"
+              }
             }
           }
         }, {

--- a/test/queryBuilder/termFilters.unit.js
+++ b/test/queryBuilder/termFilters.unit.js
@@ -27,10 +27,11 @@ module.exports = function( qb ){
         args: [ { description: "This is a description" } ],
         expected: {
           "query": {
-            "query_string": {
-              "query": "This is a description",
-              "fields": [ "description" ],
-              "default_operator": "AND"
+            "match": {
+              "description": {
+                "query": "This is a description",
+                "operator": "and"
+              }
             }
           }
         }
@@ -40,10 +41,11 @@ module.exports = function( qb ){
         expected: {
           "not": {
             "query": {
-              "query_string": {
-                "query": "This is a description",
-                "fields": [ "description" ],
-                "default_operator": "AND"
+              "match": {
+                "description": {
+                  "query": "This is a description",
+                  "operator": "and"
+                }
               }
             }
           }
@@ -394,12 +396,11 @@ module.exports = function( qb ){
         args: [ { title: "This is a title" } ],
         expected: {
           "query": {
-            "query_string": {
-              "query": "This is a title",
-              "fields": [
-                "title"
-              ],
-              "default_operator": "AND"
+            "match": {
+              "title": {
+                "query": "This is a title",
+                "operator": "and"
+              }
             }
           }
         }
@@ -409,12 +410,11 @@ module.exports = function( qb ){
         expected: {
           "not": {
             "query": {
-              "query_string": {
-                "query": "This is a title",
-                "fields": [
-                  "title"
-                ],
-                "default_operator": "AND"
+              "match": {
+                "title": {
+                  "query": "This is a title",
+                  "operator": "and"
+                }
               }
             }
           }


### PR DESCRIPTION
... and description to avoid use of special Lucene Syntax words and characters.

https://bugzilla.mozilla.org/show_bug.cgi?id=912022
