### PR TITLE
Bug 925759 - update node-webmaker-loginapi version to v0.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "nunjucks": "0.1.9",
     "querystring": "0.2.0",
     "uuid": "1.4.1",
-    "webmaker-loginapi": "https://github.com/mozilla/node-webmaker-loginapi/tarball/v0.1.14"
+    "webmaker-loginapi": "https://github.com/mozilla/node-webmaker-loginapi/tarball/v0.1.15"
   },
   "devDependencies": {
     "grunt": "0.4.1",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=925759
