### PR TITLE
Bug 925759 - Use getUserByUsername, not Email for likes and dislikes

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -163,7 +163,7 @@ module.exports = function( makeModel, apiUserModel, env ) {
     },
     like: function( req, res, next ) {
       var make = req.make;
-      loginApi.getUserByEmail( req.body.maker, function( err, user ) {
+      loginApi.getUserByUsername( req.body.maker, function( err, user ) {
         if ( err ) {
           return next( err );
         }
@@ -183,7 +183,7 @@ module.exports = function( makeModel, apiUserModel, env ) {
     },
     unlike: function( req, res, next ) {
       var make = req.make;
-      loginApi.getUserByEmail( req.body.maker, function( err, user ) {
+      loginApi.getUserByUsername( req.body.maker, function( err, user ) {
         if ( err ) {
           return next( err );
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=925759
