### PR TITLE
csrf-token rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "habitat": "0.4.1",
     "hawk": "1.0.0",
     "helmet": "0.0.11",
-    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.7",
+    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.12",
     "messina": "0.1.1",
     "mongoose": "3.5.2",
     "mongoose-validator": "0.2.1",

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -342,7 +342,7 @@ document.addEventListener( "DOMContentLoaded", function() {
     return this;
   };
 
-  var csrfToken = document.querySelector( "meta[name=csrf_token]" ).getAttribute( "content" ),
+  var csrfToken = document.querySelector( "meta[name=csrf-token]" ).getAttribute( "content" ),
       make = new window.Make({
         apiURL: "/admin",
         csrf: csrfToken
@@ -451,7 +451,7 @@ document.addEventListener( "DOMContentLoaded", function() {
     var request = new XMLHttpRequest();
 
     request.open( "POST", "/admin/api/user", true );
-    request.setRequestHeader( "x-csrf-token", csrfToken );
+    request.setRequestHeader( "X-CSRF-Token", csrfToken ); // express.js uses a non-standard name for csrf-token
     request.setRequestHeader( "Content-Type", "application/json; charset=utf-8" );
     request.onreadystatechange = function() {
       var response,
@@ -496,7 +496,7 @@ document.addEventListener( "DOMContentLoaded", function() {
       var request = new XMLHttpRequest();
 
       request.open( "POST", "/persona/logout", true );
-      request.setRequestHeader( "x-csrf-token", csrfToken );
+      request.setRequestHeader( "X-CSRF-Token", csrfToken ); // express.js uses a non-standard name for csrf-token
       request.addEventListener( "loadend", function() {
         window.location.replace( "./login" );
       }, false);

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -5,7 +5,7 @@
 $(function() {
   var submit = $("#submit"),
       identity = $("meta[name=persona-email]").attr("content") || null,
-      csrfToken = $("meta[name=csrf_token]").attr("content");
+      csrfToken = $("meta[name=csrf-token]").attr("content");
 
   submit.click(function() {
     navigator.idSSO.request();
@@ -17,7 +17,7 @@ $(function() {
 
       request.open( "POST", "/persona/verify", true );
       request.setRequestHeader( "Content-Type", "application/json" );
-      request.setRequestHeader( "x-csrf-token", csrfToken );
+      request.setRequestHeader( "X-CSRF-Token", csrfToken ); // express.js uses a non-standard name for csrf-token
       request.addEventListener( "loadend", function() {
         try {
           var data = JSON.parse( this.response );

--- a/views/admin.html
+++ b/views/admin.html
@@ -6,7 +6,7 @@
 <html>
   <head>
     <title>Make Editor</title>
-    <meta name="csrf_token" content="{{csrf}}" >
+    <meta name="csrf-token" content="{{csrf}}" >
     <meta name="is_collaborator" content="{{iscollaborator}}">
     <meta name="webmaker_hostname" content="{{audience}}">
     <script src="js/external/jquery.min.js"></script>

--- a/views/login.html
+++ b/views/login.html
@@ -8,7 +8,7 @@
     <title>Sign in</title>
     <meta charset="utf-8">
     <meta name="persona-email" content="{{email}}">
-    <meta name="csrf_token" content="{{csrf}}" >
+    <meta name="csrf-token" content="{{csrf}}" >
     <link rel="stylesheet" href="{{login}}/css/nav.css" />
   </head>
   <body>


### PR DESCRIPTION
switch from "X-CSRF-Token" as meta name to the validation-passing "csrf-token"

https://bugzilla.mozilla.org/show_bug.cgi?id=930166
