### PR TITLE
Update async to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Webmaker Product Team <webmaker-staff@mozillafoundation.org>",
   "license": "MPL-2.0",
   "dependencies": {
-    "async": "0.2.9",
+    "async": "0.8.0",
     "express": "3.4.5",
     "habitat": "1.1.0",
     "hatchet": "0.1.0",


### PR DESCRIPTION
There's some packages that expect 0.2.x, not sure if that's a problem
