### PR TITLE
remove a useless check that broke between node 0.10 and 0.12

### DIFF
--- a/lib/queryBuilder/queryTypes/search.js
+++ b/lib/queryBuilder/queryTypes/search.js
@@ -173,10 +173,6 @@ function likedByUserQuery(queryData, callback) {
 // DSL generator function - accepts an object that defines a query
 // and a callback to pass the generated DSL to
 module.exports = function (query, callback, authenticated) {
-  if (!(query && query.constructor === Object) || !(callback && typeof callback === "function")) {
-    throw new Error("Check your arguments.");
-  }
-
   query.limit = +query.limit;
   query.page = +query.page;
 

--- a/test/queryBuilder/search/core.unit.js
+++ b/test/queryBuilder/search/core.unit.js
@@ -36,15 +36,6 @@ module.exports = function (qb) {
     [null],
     [null, null],
     [undefined, null]
-    // [null, undefined],
-    // [{}],
-    // [null, nop],
-    // [nop, {}],
-    // ["foo", "bar"],
-    // [1, "bar"],
-    // ["bar", 1],
-    // [/lolwut/, nop],
-    // [nop, /lolwut/]
   ];
 
   return {

--- a/test/queryBuilder/search/core.unit.js
+++ b/test/queryBuilder/search/core.unit.js
@@ -27,8 +27,7 @@ module.exports = function (qb) {
       },
       size: 10,
       from: 0
-    },
-    nop = function () {};
+    };
 
   var badArgList = [
     [],
@@ -36,16 +35,16 @@ module.exports = function (qb) {
     [undefined, undefined]
     [null],
     [null, null],
-    [undefined, null],
-    [null, undefined],
-    [{}],
-    [null, nop],
-    [nop, {}],
-    ["foo", "bar"],
-    [1, "bar"],
-    ["bar", 1],
-    [/lolwut/, nop],
-    [nop, /lolwut/]
+    [undefined, null]
+    // [null, undefined],
+    // [{}],
+    // [null, nop],
+    // [nop, {}],
+    // ["foo", "bar"],
+    // [1, "bar"],
+    // ["bar", 1],
+    // [/lolwut/, nop],
+    // [nop, /lolwut/]
   ];
 
   return {


### PR DESCRIPTION
fixes #242 

I have no idea why this check exists, but it's not necessary, and `obj.constructor` doesn't exist anymore

@jbuck R?